### PR TITLE
Fix for 4 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "main": "./alchemyapi.js",
   "dependencies": {
     "express": "3.4.0",
-    "request": "~2.27.0",
+    "request": "~2.74.0",
     "consolidate": "~0.9.1",
     "dustjs-linkedin": "~2.0.3"
   }


### PR DESCRIPTION
alchemyapi_node currently has a 14 vulnerable dependency paths, introducing 9 different types of known vulnerabilities.

This PR fixes vulnerable dependencies.
- [ReDOS vulnerability](https://snyk.io/vuln/npm:hawk:20160119) in the `hawk` dependency.
- [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency.
- [Denial of Service (Event Loop Blocking) vulnerability](https://snyk.io/vuln/npm:qs:20140806-1) in the `qs` dependency.
- [Denial of Service (Memory Exhaustion)](https://snyk.io/vuln/npm:qs:20140806) in the `qs` dependency.

You can see [Snyk test report](https://snyk.io/test/github/AlchemyAPI/alchemyapi_node) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix the vulnerabilities listed above.

You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Note this PR fixes all the vulnerabilities introduced trough `request` dependency, in order to be vulnerability free you will need to upgrade others dependencies as well.

Stay Secure,
The Snyk Team
